### PR TITLE
Re-exported dependency

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@ use proto::stream::Kind;
 pub mod proto;
 pub mod read;
 
+pub use fallible_streaming_iterator;
+
 #[derive(Debug, Clone)]
 pub enum Error {
     OutOfSpec,

--- a/tests/it/deserialize.rs
+++ b/tests/it/deserialize.rs
@@ -1,5 +1,5 @@
-use fallible_streaming_iterator::FallibleStreamingIterator;
 use orc_format::{
+    fallible_streaming_iterator::FallibleStreamingIterator,
     proto::{column_encoding::Kind as ColumnEncodingKind, stream::Kind},
     read,
     read::decode::{


### PR DESCRIPTION
So that it can be used by consumers without having to add it.